### PR TITLE
Update changelog.txt

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -41,6 +41,7 @@ Version: 1.1.0
 Date: 2020-11-30
   Info:
     - Update for Factorio 1.1.
+    - Restore Belt Brush compatibility.
 ---------------------------------------------------------------------------------------------------
 Version: 1.0.3
 Date: 2020-09-11
@@ -57,12 +58,6 @@ Version: 1.0.1
 Date: 2020-09-09
   Bugfixes:
     - Fix crash on startup due to missing icon_size. (https://mods.factorio.com/mod/beltlayer/discussion/5f58e93537b59eef7dac5b1e)
----------------------------------------------------------------------------------------------------
-Version: 1.1.0
-Date: 2020-11-30
-  Info:
-    - Update to Factorio 1.1.
-    - Restore Belt Brush compatibility.
 ---------------------------------------------------------------------------------------------------
 Version: 1.0.0
 Date: 2020-09-08


### PR DESCRIPTION
Removed duplicate entry for version 1.1.0. 
The in-game changelog parser does not allow two entries with the same version number and prevented the changelog from being read in-game